### PR TITLE
Fixup: Thermomechanics test

### DIFF
--- a/Thermomechanics/NonlinearBar/CMakeLists.txt
+++ b/Thermomechanics/NonlinearBar/CMakeLists.txt
@@ -2,4 +2,4 @@ set(testFiles "amgx.json;1dbar.exo")
 set(testFiles "${testFiles};Thermomechanics_NonlinearBar_layout.png;index.dox")
 set(testFiles "${testFiles};temperature_plot.gnu;displacement_plot.gnu")
 
-add_verification_test("1dbar.xml" "output_data" "temperature;displacement" ${testFiles})
+add_verification_test("1dbar.xml" "output_data" "temperature;displacement" "${testFiles}")

--- a/Thermomechanics/StaticNonlinearBar/CMakeLists.txt
+++ b/Thermomechanics/StaticNonlinearBar/CMakeLists.txt
@@ -2,4 +2,4 @@ set(testFiles "amgx.json;1dbar.exo")
 set(testFiles "${testFiles};Thermomechanics_StaticNonlinearBar_layout.png;index.dox")
 set(testFiles "${testFiles};temperature_plot.gnu;displacement_plot.gnu")
 
-add_verification_test("1dbar.xml" "output_data" "temperature;displacement" ${testFiles})
+add_verification_test("1dbar.xml" "output_data" "temperature;displacement" "${testFiles}")


### PR DESCRIPTION
Fixes missing quotes in CMake macro call. All the test files weren't being copied to the build directory.