### PR TITLE
disable NonlinearBar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ ADD_SUBDIRECTORY(Mechanical/TransientDynamicsAFormExplicit)
 endif()
 
 if(PARABOLIC)
-ADD_SUBDIRECTORY(Thermomechanics/NonlinearBar)
+#ADD_SUBDIRECTORY(Thermomechanics/NonlinearBar)
 endif()
 
 if(HATCHING)


### PR DESCRIPTION
Turning off analyze tests of transient thermomechanics. I'm not aware of a way to use the "expected fail" test type we just created in PE, so just turned it off.